### PR TITLE
Increase atol value from 10-6 to 10-5

### DIFF
--- a/vast/opensetAlgos/EVM.py
+++ b/vast/opensetAlgos/EVM.py
@@ -247,8 +247,8 @@ def EVM_Training(
         assert torch.allclose(
             positive_distances[e].type(torch.FloatTensor),
             torch.zeros(positive_distances.shape[0]),
-            atol=1e-06,
-        ), "Distances of samples to themselves is not zero. This may be due to a precision issue, try increasing the atol value from 1e-06 to 1e-05."
+            atol=1e-05,
+        ), "Distances of samples to themselves is not zero. This may be due to a precision issue, try increasing the atol value from 1e-05 to 1e-04."
 
         for distance_multiplier, cover_threshold, org_tailsize in itertools.product(
             args.distance_multiplier, args.cover_threshold, args.tailsize


### PR DESCRIPTION
This PR increases the atol value from 10-6  to 10-5. This fixes the assertion error that was causing the downstream agent to fail.